### PR TITLE
Migration from 'imagesize' to 'image-size' module for .svg format support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var through2 = require("through2"),
-  imagesize = require("imagesize"),
+  sizeOf = require("image-size"),
   libpath = require("path"),
   defaults = require("lodash/defaults"),
   cssimage = require("css-image");
@@ -31,14 +31,13 @@ module.exports = function (param) {
     }
     // check if file.contents is a `Buffer`
     if (file.isBuffer() || file.isFile()) {
-      var parser = imagesize.Parser();
-
-      var retStatus = parser.parse(file.contents);
-      if (imagesize.Parser.DONE === retStatus) {
-        var result = parser.getResult();
-        result.file = libpath.relative(file.base, file.path)
-        info.push(result);
-      }
+	  try {
+		var result = sizeOf(file.path);
+		
+		result.file = libpath.relative(file.base, file.path);      
+		info.push(result);    
+	  } catch(e) {
+	  }
     }
     return callback();
   }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "css-image": "0.2.3",
     "gulp-util": "3.0.7",
-    "imagesize": "1.0.0",
+    "image-size": "^0.6.2",
     "lodash": "4.13.1",
     "through2": "2.0.1"
   },


### PR DESCRIPTION
I suggest to get rid of 'imagesize' that supports only 'gif', 'jpeg', 'png' formats and use 'image-size' instead. 

'[image-size](https://github.com/image-size/image-size)' supports following formats:

BMP, CUR, GIF, ICO, JPEG, PNG, PSD, TIFF, WebP, SVG, DDS

I need svg for my project.